### PR TITLE
Security fix for github.com/jinzhu/gorm

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang/protobuf v1.2.0
 	github.com/google/gops v0.3.6
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
-	github.com/jinzhu/gorm v1.9.2
+	github.com/jinzhu/gorm v1.9.10
 	github.com/jinzhu/now v1.0.0 // indirect
 	github.com/koding/multiconfig v0.0.0-20171124222453-69c27309b2d7
 	github.com/pkg/errors v0.8.1


### PR DESCRIPTION
github.com/jinzhu/gorm v1.9.2 is vulnerable. request you to update the version.Please see details here:
https://search.gocenter.io/github.com~2Fjinzhu~2Fgorm/info?version=v1.9.2

CVE-2019-15562 
GORM before 1.9.10 allows SQL injection via incomplete parentheses. 